### PR TITLE
chore: bump poseidon to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "idc-nullifier",
-    "version": "0.0.1",
+    "version": "0.0.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "idc-nullifier",
-            "version": "0.0.1",
+            "version": "0.0.3",
             "license": "MIT",
             "dependencies": {
                 "@semaphore-protocol/identity": "^3.10.1",
                 "circomlib": "^2.0.5",
-                "poseidon-lite": "^0.0.2",
+                "poseidon-lite": "^0.2.0",
                 "snarkjs": "^0.7.0"
             },
             "devDependencies": {
@@ -6099,9 +6099,9 @@
             }
         },
         "node_modules/poseidon-lite": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/poseidon-lite/-/poseidon-lite-0.0.2.tgz",
-            "integrity": "sha512-bGdDPTOQkJbBjbtSEWc3gY+YhqlGTxGlZ8041F8TGGg5QyGGp1Cfs4b8AEnFFjHbkPg6WdWXUgEjU1GKOKWAPw=="
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/poseidon-lite/-/poseidon-lite-0.2.0.tgz",
+            "integrity": "sha512-vivDZnGmz8W4G/GzVA72PXkfYStjilu83rjjUfpL4PueKcC8nfX6hCPh2XhoC5FBgC6y0TA3YuUeUo5YCcNoig=="
         },
         "node_modules/prelude-ls": {
             "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "@semaphore-protocol/identity": "^3.10.1",
         "circomlib": "^2.0.5",
-        "poseidon-lite": "^0.0.2",
+        "poseidon-lite": "^0.2.0",
         "snarkjs": "^0.7.0"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,68 +1,68 @@
 {
-    "name": "idc-nullifier",
-    "license": "MIT",
-    "version": "0.0.3",
-    "publishConfig": {
-        "access": "public"
-    },
-    "contributors": [
-        {
-            "name": "AtHeartEngineer"
-        }
-    ],
-    "main": "./dist/index.node.cjs",
-    "module": "./dist/index.mjs",
-    "browser": {
-        "./dist/index.node.cjs": "./dist/index.mjs"
-    },
-    "types": "./dist/types/index.d.ts",
-    "directories": {
-        "dist": "./dist",
-        "src": "./src",
-        "test": "./tests"
-    },
-    "files": [
-        "dist/",
-        "LICENSE",
-        "README.md"
-    ],
-    "scripts": {
-        "build-circuit": "./scripts/build-circuits.sh",
-        "build": "npm run build-circuit && npm run build-js",
-        "build-js": "rollup --config rollup.config.mjs",
-        "test": "jest",
-        "test-dev": "npm run test -- --silent=false"
-    },
-    "dependencies": {
-        "@semaphore-protocol/identity": "^3.10.1",
-        "circomlib": "^2.0.5",
-        "poseidon-lite": "^0.2.0",
-        "snarkjs": "^0.7.0"
-    },
-    "devDependencies": {
-        "@rollup/plugin-commonjs": "^24.0.1",
-        "@rollup/plugin-json": "^6.0.0",
-        "@rollup/plugin-node-resolve": "^15.0.1",
-        "@rollup/plugin-replace": "^5.0.2",
-        "@types/jest": "^29.2.4",
-        "@typescript-eslint/eslint-plugin": "^5.50.0",
-        "@typescript-eslint/parser": "^5.51.0",
-        "eslint": "^8.33.0",
-        "eslint-config-airbnb-base": "^15.0.0",
-        "eslint-config-airbnb-typescript": "^17.0.0",
-        "eslint-import-resolver-typescript": "^3.5.3",
-        "eslint-plugin-import": "^2.27.5",
-        "jest": "^29.5.0",
-        "prettier": "^2.8.1",
-        "rollup": "^3.14.0",
-        "rollup-plugin-cleaner": "^1.0.0",
-        "rollup-plugin-copy": "^3.4.0",
-        "rollup-plugin-polyfill-node": "^0.12.0",
-        "rollup-plugin-typescript2": "^0.34.1",
-        "rollup-plugin-visualizer": "^5.9.0",
-        "ts-jest": "^29.0.3",
-        "ts-node": "^10.9.1",
-        "tslib": "^2.5.0",
-        "typescript": "^4.9.5"
+  "name": "idc-nullifier",
+  "license": "MIT",
+  "version": "0.0.3",
+  "publishConfig": {
+    "access": "public"
+  },
+  "contributors": [
+    {
+      "name": "AtHeartEngineer"
     }
+  ],
+  "main": "./dist/index.node.cjs",
+  "module": "./dist/index.mjs",
+  "browser": {
+    "./dist/index.node.cjs": "./dist/index.mjs"
+  },
+  "types": "./dist/types/index.d.ts",
+  "directories": {
+    "dist": "./dist",
+    "src": "./src",
+    "test": "./tests"
+  },
+  "files": [
+    "dist/",
+    "LICENSE",
+    "README.md"
+  ],
+  "scripts": {
+    "build-circuit": "./scripts/build-circuits.sh",
+    "build": "npm run build-circuit && npm run build-js",
+    "build-js": "rollup --config rollup.config.mjs",
+    "test": "jest",
+    "test-dev": "npm run test -- --silent=false"
+  },
+  "dependencies": {
+    "@semaphore-protocol/identity": "^3.10.1",
+    "circomlib": "^2.0.5",
+    "poseidon-lite": "^0.2.0",
+    "snarkjs": "^0.7.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^24.0.1",
+    "@rollup/plugin-json": "^6.0.0",
+    "@rollup/plugin-node-resolve": "^15.0.1",
+    "@rollup/plugin-replace": "^5.0.2",
+    "@types/jest": "^29.2.4",
+    "@typescript-eslint/eslint-plugin": "^5.50.0",
+    "@typescript-eslint/parser": "^5.51.0",
+    "eslint": "^8.33.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-airbnb-typescript": "^17.0.0",
+    "eslint-import-resolver-typescript": "^3.5.3",
+    "eslint-plugin-import": "^2.27.5",
+    "jest": "^29.5.0",
+    "prettier": "^2.8.1",
+    "rollup": "^3.14.0",
+    "rollup-plugin-cleaner": "^1.0.0",
+    "rollup-plugin-copy": "^3.4.0",
+    "rollup-plugin-polyfill-node": "^0.12.0",
+    "rollup-plugin-typescript2": "^0.34.1",
+    "rollup-plugin-visualizer": "^5.9.0",
+    "ts-jest": "^29.0.3",
+    "ts-node": "^10.9.1",
+    "tslib": "^2.5.0",
+    "typescript": "^4.9.5"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { groth16 } from 'snarkjs';
 import type { SNARKProof, VerificationKey, Witness } from './types';
-import poseidon from 'poseidon-lite';
+import { poseidon1 } from 'poseidon-lite/poseidon1';
+import { poseidon2 } from 'poseidon-lite/poseidon2';
 import { Identity } from '@semaphore-protocol/identity';
 import verificationKey from './zkeyFiles/idcNullifier/verification_key.json';
 
@@ -26,7 +27,7 @@ export class Prover {
     identity: Identity;
     externalNullifier: bigint;
   }): Promise<SNARKProof> {
-    const identitySecret = poseidon([args.identity.trapdoor, args.identity.nullifier]);
+    const identitySecret = poseidon2([args.identity.trapdoor, args.identity.nullifier]);
     const witness: Witness = {
       identitySecret: identitySecret,
       externalNullifier: args.externalNullifier
@@ -37,8 +38,8 @@ export class Prover {
       this._finalZkeyPath,
       null
     );
-    console.debug('idc from semaphore: ' + poseidon([BigInt(identitySecret)]));
-    console.debug('idc from generateProof: ' + poseidon([BigInt(identitySecret)]));
+    console.debug('idc from semaphore: ' + poseidon1([BigInt(identitySecret)]));
+    console.debug('idc from generateProof: ' + poseidon1([BigInt(identitySecret)]));
     const snarkProof: SNARKProof = {
       proof,
       publicSignals: {
@@ -65,7 +66,7 @@ export class Verifier {
    * @throws Error if the proof is using different parameters.
    */
   public async verifyProof(snarkProof: SNARKProof): Promise<boolean> {
-    const expectedNullifierHash = poseidon([
+    const expectedNullifierHash = poseidon2([
       BigInt(snarkProof.publicSignals.externalNullifier),
       BigInt(snarkProof.publicSignals.identityCommitment)
     ]);


### PR DESCRIPTION
This PR bumps poseidon to 0.2.0 and optimized bundle size with named import.